### PR TITLE
Add handling of negative areas and solver NaNs in general.

### DIFF
--- a/src/cvOneDBFSolver.cpp
+++ b/src/cvOneDBFSolver.cpp
@@ -1485,6 +1485,10 @@ void cvOneDBFSolver::GenerateSolution(void){
         norms = rhs->Norm(L2_norm,0,2);
       }
 
+      if (std::isnan(norms) || std::isnan(normf)) {
+          throw cvException("Calculated a NaN for the residual.");
+      }
+
       // Check Newton-Raphson Convergence
       // cout << "convCriteria" << convCriteria <<endl;
       // getchar();
@@ -1521,8 +1525,8 @@ void cvOneDBFSolver::GenerateSolution(void){
               if (startOut <= i && i <= finishOut) {
                  modelname = model-> getModelName();
                  segname = curSeg -> getSegmentName();
-                 cout << "At " << modelname << segname << " ";
-                 cout << "The area goes to " << currentSolution->Get(i) << endl;
+                 std::string msg = "ERROR: The area of segment '" + std::string(segname) + "' is negative.";
+                 throw cvException(msg.c_str());
               }
               elCount += 2*(numEls+1);
               fileIter++;
@@ -1559,6 +1563,7 @@ void cvOneDBFSolver::GenerateSolution(void){
       cout << "normf: " << normf << " ";
       cout << "norms: " << norms << " ";
       cout << "time: " << ((float)(tend_iter-tstart_iter))/CLOCKS_PER_SEC << endl;
+
 
       if(iter > MAX_NONLINEAR_ITERATIONS){
         //cout << "rhs " << *rhs << endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -672,7 +672,7 @@ int main(int argc, char** argv){
     printf("%s\n",e.what());
     // Execution Terminated      
     printf("Terminated.\n");
-    return -1;
+    return 1;
   }
   printf("Completed!\n");
   return 0;


### PR DESCRIPTION
The 1D solver does not check for residuals that are NaNs. This was occurring when outlet areas where becoming negative. I added throwing exceptions for these conditions and changed the returned error exit code from -1 to 1, exit codes are 0-255.