### PR TITLE
Add an option to build installer.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,14 +6,16 @@ PROJECT(OneDSolver)
 ENABLE_LANGUAGE(C CXX)
 
 # Get the SimVascular variables for libraries, includes, etc.
-find_package(SimVascular REQUIRED)
-
-# Set the path to find the SimVascular CMake modules.
-set(CMAKE_MODULE_PATH "${SimVascular_CMAKE_DIR}" "${CMAKE_MODULE_PATH}")
-include(SimVascularMacros)
-include(SimVascularSystemSetup)
+if (BUILD_SV_INSTALLER) 
+    find_package(SimVascular REQUIRED)
+    # Set the path to find the SimVascular CMake modules.
+    set(CMAKE_MODULE_PATH "${SimVascular_CMAKE_DIR}" "${CMAKE_MODULE_PATH}")
+    include(SimVascularMacros)
+    include(SimVascularSystemSetup)
+ENDIF()
 
 # SET OPTIONS
+OPTION(BUILD_SV_INSTALLER "Build SimVascular Installer" OFF)
 OPTION(buildPy "Build Python Interface" OFF)
 OPTION(buildDocs "Build Documentation" OFF)
 SET(sparseSolverType "skyline" CACHE STRING "Use Sparse Solver")
@@ -93,9 +95,7 @@ IF(buildPy)
 
 ENDIF()
 
-add_subdirectory("${CMAKE_SOURCE_DIR}/Distribution")
-
-
-
-
+if (BUILD_SV_INSTALLER) 
+    add_subdirectory("${CMAKE_SOURCE_DIR}/Distribution")
+ENDIF()
 


### PR DESCRIPTION
The CMakeLists.txt assumed that an SV source build is present so that an installer can be built. An SV source build should really not be needed to build the 1D solver so make the installer build optional.