### PR TITLE
Fix bugs in Olufsen material and PRESSURE boundary condition

### DIFF
--- a/Code/Source/cvOneDMaterialOlufsen.cxx
+++ b/Code/Source/cvOneDMaterialOlufsen.cxx
@@ -276,7 +276,7 @@ double cvOneDMaterialOlufsen::GetN(double S)const{
   double del  = sqrt(kinematicViscosity*T/2.0/PI); // from Lighthill, olufsen's thesis, pg56
   double altN = -2.0*PI*kinematicViscosity*R/del; // == -1.45838*r
 
-  return altN;
+  return N;
 
 }
 

--- a/Code/Source/cvOneDMthModelBase.cxx
+++ b/Code/Source/cvOneDMthModelBase.cxx
@@ -160,7 +160,7 @@ void cvOneDMthModelBase::SetBoundaryConditions(){
   */
     switch(sub->GetBoundCondition()){
     case BoundCondTypeScope::PRESSURE:
-      (*currSolution)[eqNumbers[0]] = sub->GetBoundAreabyPresWave(currentTime);
+      (*currSolution)[eqNumbers[0]] = sub->GetBoundFlowRate();
       break;
     case BoundCondTypeScope::FLOW:
       (*currSolution)[eqNumbers[1]] = sub->GetBoundFlowRate();
@@ -260,7 +260,8 @@ void cvOneDMthModelBase::ApplyBoundaryConditions(){
       switch(sub->GetBoundCondition()){
         case BoundCondTypeScope::PRESSURE:
         case BoundCondTypeScope::PRESSURE_WAVE:
-
+          cvOneDGlobal::solver->SetSolution( eqNumbers[0], value);
+          break;
         case BoundCondTypeScope::FLOW:
           cvOneDGlobal::solver->SetSolution( eqNumbers[1], value);
           break;
@@ -387,6 +388,8 @@ void cvOneDMthModelBase::ApplyBoundaryConditions(){
           // so same treatment as regular Essential BC like in Brooke's
           case BoundCondTypeScope::PRESSURE:
           case BoundCondTypeScope::PRESSURE_WAVE:
+            cvOneDGlobal::solver->SetSolution( eqNumbers[0], value);
+            break;
           case BoundCondTypeScope::FLOW:
             cvOneDGlobal::solver->SetSolution( eqNumbers[1], value);
             break;

--- a/test/tube_pressure.in
+++ b/test/tube_pressure.in
@@ -1,0 +1,39 @@
+MODEL results_pressure_
+
+NODE 0 0.0 0.0 0.0
+NODE 1 0.0 0.0 10.0
+
+SEGMENT seg 0 10.0 50 0 1 1.0 1.0 0.0 MAT1 NONE 0.0 0 0 PRESSURE OUTLETDATA
+
+DATATABLE INLETDATA LIST
+0.0 100.0
+10.0 100.0
+ENDDATATABLE
+
+# warning: pressure boundary condition converts pressure by multiplying with 1333.2237
+# 7.50061673821 mmHg = 10000 dyn/cm2
+DATATABLE OUTLETDATA LIST
+0.0 7.50061673821
+ENDDATATABLE
+
+SOLVEROPTIONS 0.001 1000 1000 2 INLETDATA FLOW 1.0e-8 1 1
+
+MATERIAL MAT1 OLUFSEN 1.06 0.04 0 2.0 1.0e15 -20 1e9
+
+OUTPUT TEXT
+
+# analytical solution
+
+# parameters
+# viscosity		mu	0.04
+# vessel length		L	10
+# vessel cross-section	A	1
+# vessel radius		r	0.5641895835
+# pressure outlet       Pout	10000
+# prescribed inflow	Q	100
+
+# reference solution
+# vessel resistance	R1 = 8*mu*L*PI/A^2 = 10.05309649
+
+# results to be checked
+# pressure inlet	Pin = Pout + Q*R1 = 11005.30965

--- a/test/tube_r.in
+++ b/test/tube_r.in
@@ -1,0 +1,38 @@
+MODEL results_r_
+
+NODE 0 0.0 0.0 0.0
+NODE 1 0.0 0.0 10.0
+
+SEGMENT seg 0 10.0 50 0 1 1.0 1.0 0.0 MAT1 NONE 0.0 0 0 RESISTANCE OUTLETDATA
+
+DATATABLE INLETDATA LIST
+0.0 100.0
+10.0 100.0
+ENDDATATABLE
+
+DATATABLE OUTLETDATA LIST
+0.0 100.0
+ENDDATATABLE
+
+SOLVEROPTIONS 0.001 1000 1000 2 INLETDATA FLOW 1.0e-8 1 1
+
+MATERIAL MAT1 OLUFSEN 1.06 0.04 0 2.0 1.0e15 -20 1e9
+
+OUTPUT TEXT
+
+# analytical solution
+
+# parameters
+# viscosity             mu      0.04
+# vessel length         L       10
+# vessel cross-section  A       1
+# vessel radius         r       0.5641895835
+# resistance BC         R2      100
+# prescribed inflow     Q       100
+
+# reference solution
+# vessel resistance     R1 = 8*mu*L*PI/A^2 = 10.05309649
+
+# results to be checked
+# pressure inlet	Pin  = Q*(R1+R2) =	11005.30965
+# pressure outlet	Pout = Q*R2 =		10000

--- a/test/tube_rcr.in
+++ b/test/tube_rcr.in
@@ -1,0 +1,44 @@
+MODEL results_rcr_
+
+NODE 0 0.0 0.0 0.0
+NODE 1 0.0 0.0 10.0
+
+SEGMENT seg 0 10.0 50 0 1 1.0 1.0 0.0 MAT1 NONE 0.0 0 0 RCR OUTLETDATA
+
+DATATABLE INLETDATA LIST
+0.0 100.0
+10.0 100.0
+ENDDATATABLE
+
+# emulating an R boundary condition for static testing
+# C = 0
+# R = 50 + 50 = 100
+DATATABLE OUTLETDATA LIST
+0.0 50.0
+0.0 0.001
+0.0 50.0
+ENDDATATABLE
+
+SOLVEROPTIONS 0.001 1000 1000 2 INLETDATA FLOW 1.0e-8 1 1
+
+MATERIAL MAT1 OLUFSEN 1.06 0.04 0 2.0 1.0e15 -20 1e9
+
+OUTPUT TEXT
+
+# analytical solution
+
+# parameters
+# viscosity             mu      0.04
+# vessel length         L       10
+# vessel cross-section  A       1
+# vessel radius         r       0.5641895835
+# resistance BC         R2 	100
+# prescribed inflow     Q       100
+
+# reference solution
+# vessel resistance     R1 = 8*mu*L*PI/A^2 = 10.05309649
+
+# results to be checked
+# pressure inlet        Pin  = Q*(R1+R2) =      11005.30965
+# pressure outlet       Pout = Q*R2 =           10000
+


### PR DESCRIPTION
This fixes #49 #50 #51 #54.

Results are tested with three test cases using Olufsen material combined with R, RCR, and PRESSURE boundary conditions. All test cases contain an analytical reference solution that is recovered by svOneDSolver within a relative error of 1e-6.