### PR TITLE
Make tangent matrix computation more robust

### DIFF
--- a/Code/Source/cvOneDBFSolver.h
+++ b/Code/Source/cvOneDBFSolver.h
@@ -65,7 +65,7 @@ class cvOneDBFSolver{
     static void SetInletBCType(BoundCondType bc);
     static void SetMaxStep(long maxs);
     static void SetQuadPoints(long quadPoints_);
-	static void SetConvergenceCriteria(double convCriteria);
+    static void SetConvergenceCriteria(double convCriteria);
 
     // Set the Model Pointer
     static void SetModelPtr(cvOneDModel *mdl);
@@ -82,11 +82,12 @@ class cvOneDBFSolver{
 
     static void DefineInletFlow(double* time, double* flrt, int num);
 
-	static void QuerryModelInformation(void);
+    static void QuerryModelInformation(void);
     static double currentTime;
     static double deltaTime;
-	static BoundCondType inletBCtype;
-	static int ASCII;
+    static BoundCondType inletBCtype;
+    static bool useFiniteDifferencesTangent;
+    static int ASCII;
 
     // Result Output
     static void postprocess_Text();
@@ -136,9 +137,8 @@ class cvOneDBFSolver{
     static long numFlowPts;
     static double *flowRate;
     static double *flowTime;
-	static double Period;
-	static double convCriteria;
-
+    static double Period;
+    static double convCriteria;
 };
 
 #endif //CVONEDBFSOLVER_H

--- a/Code/Source/cvOneDMthSegmentModel.h
+++ b/Code/Source/cvOneDMthSegmentModel.h
@@ -68,6 +68,7 @@ class cvOneDMthSegmentModel : public cvOneDMthModelBase{
   private:
 
     void FormElementLHS(long element, cvOneDDenseMatrix* elementMatrix, long ithSubdomain);
+    void FormElementLHSFD(long element, cvOneDDenseMatrix* elementMatrix, long ithSubdomain);
     void FormElementRHS(long element, cvOneDFEAVector* elementVector, long ithSubdomain);
     void FormMixedBCLHS(int ith, cvOneDSubdomain* sub, cvOneDDenseMatrix* elementMatrix){;}
     void FormMixedBCRHS(int ith, cvOneDSubdomain* sub, cvOneDDenseMatrix* elementMatrix){;}


### PR DESCRIPTION
The current implementation of svOneDSolver uses an inconsistent Jacobian matrix in which some of the terms are assumed constant during the Newton iterations. This generally works well but sometimes the inexact Jacobian causes the area of certain segments to become negative, which causes the program to launch an uncaught exception. 
Considering a simple first-order finite differences approximation of the Jacobian seems to be a more stable solution in these cases. The finite-difference approximation has also the advantage of reducing the number of Newton iterations w.r.t. the inexact Jacobian. However, the computational cost of a single iteration is higher which causes the solver to be less performant (2 - 4 times). For this reason, the inexact Jacobian is kept the default choice and the finite difference approximation is used only when the solver fails for the first time.
I attach an input file for which the default tangent fails in the first timestep and this version of the code automatically switches to the approximated tangent.
[failure_1sttimestep.in.zip](https://github.com/SimVascular/svOneDSolver/files/6935135/failure_1sttimestep.in.zip)